### PR TITLE
Flexible proving for segments

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -9,6 +9,9 @@ pub enum Status {
     
     // param: error message
     ExecutionFailed(String),
+
+    // param: error message
+    UploadFailed(String),
 }
 
 #[derive(Debug, PartialEq, Eq)]


### PR DESCRIPTION
Segment proving changes a bit. we retry to prove segments that have failed with 'ExecutionFailed'status  due to some issue with Risc0 r0vm with reentrancy. So, when picking a segment to prove, only those with 'ExecutionSucceeded' and 'UploadFailed' are ignored.