### PR TITLE
The client gets notified upon job completion

### DIFF
--- a/src/job.rs
+++ b/src/job.rs
@@ -27,6 +27,8 @@ pub enum JobType {
 pub struct Job {
     // job id as specified by the client
     pub base_id: String, 
+
+    pub working_dir: String,
     
     // the client
     pub owner: PeerId,


### PR DESCRIPTION
We previously required provers to update client by explicit gossip. But from now on, prover notifies job owner upon successful completion of the job. Note that timely gossips to update is still there.
I also added some simplifications and more structured layout for storing proofs.