### PR TITLE
>>> leaner codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,15 @@ To install Risc0, please follow the following [guide](https://github.com/risc0/r
 
 Docker runtime is needed as it is used to run `Risc0` containers. This awesome [guide](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-on-ubuntu-20-04) from DigitalOcean is helpful in this regard.
 
+#### MongoDB
+
+Install the MongoDB from [here](https://www.mongodb.com/docs/manual/tutorial/install-mongodb-community-with-docker/). Make sure a Docker container runs and is listenning on `localhost:27017`. 
+
 ### Library dependencies
 
-To run a prover node, you would first need to fork the following libraries and put them in the parent("..") directory of the project:
+To run, download the the following libraries and put them in the parent("..") directory:
 
-- [comms](https://github.com/WholesumNet/comms)
+- [peyk](https://github.com/WholesumNet/peyk)
 
 ### USAGE
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -8,9 +8,9 @@ pub enum JobKind {
 
     Zkr([u8; 32]),
 
-    Segment(u32),
+    Segment(u128),
 
-    Join(u32),
+    Join(u128),
     
     Groth16,
 }
@@ -18,7 +18,7 @@ pub enum JobKind {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Proof {   
     // job_id assigned by the client 
-    pub client_job_id: String,
+    pub client_job_id: u128,
     // job_id from prover pov: job_id+item_id
     pub job_id: String,
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -4,13 +4,11 @@ use serde::{
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum JobKind {
-    Keccak([u8; 32]),
+    Assumption(String),
 
-    Zkr([u8; 32]),
+    Segment(String),
 
-    Segment(u128),
-
-    Join(u128),
+    Join(String),
     
     Groth16,
 }
@@ -18,17 +16,16 @@ pub enum JobKind {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Proof {   
     // job_id assigned by the client 
-    pub client_job_id: u128,
+    pub client_job_id: String,
     // job_id from prover pov: job_id+item_id
     pub job_id: String,
 
     pub kind: JobKind,
 
     // the client
-    pub owner: String,
+    pub owner: Vec<u8>,
 
     pub input_blobs: Vec<Vec<u8>>,    
     pub blob: Vec<u8>,    
-    pub hash: u128,
-
+    pub hash: String,
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -3,29 +3,29 @@ use serde::{
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum JobKind {
+pub enum ProveKind {
     Assumption(String),
 
     Segment(String),
 
     Join(String),
     
-    Groth16,
+    Groth16(String),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Proof {   
-    // job_id assigned by the client 
-    pub client_job_id: String,
-    // job_id from prover pov: job_id+item_id
+pub struct Proof {  
+    // as specified by the client 
     pub job_id: String,
 
-    pub kind: JobKind,
+    // hash of the input blobs
+    pub input_hashes: Vec<String>,   
+
+    pub kind: ProveKind,
 
     // the client
     pub owner: Vec<u8>,
 
-    pub input_blobs: Vec<Vec<u8>>,    
     pub blob: Vec<u8>,    
     pub hash: String,
 }

--- a/src/job.rs
+++ b/src/job.rs
@@ -17,11 +17,7 @@ pub enum Status {
 
 #[derive(Debug, PartialEq, Eq)]
 pub enum Kind {
-    // param: claim digest
-    Keccak([u8; 32]),
-
-    // param: claim digest
-    Zkr([u8; 32]),
+    Assumption(u128),
 
     // param: batch id
     Segment(u128),
@@ -29,7 +25,7 @@ pub enum Kind {
     // param: batch id
     Join(u128),
 
-    Groth16,
+    Groth16(u128),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -45,7 +41,7 @@ pub struct Token {
     // xxh3_128
     pub hash: u128,
 
-    pub owners: Vec<String>
+    pub owners: Vec<Vec<u8>>
 }
 
 // maintain lifecycle of a job

--- a/src/job.rs
+++ b/src/job.rs
@@ -24,10 +24,10 @@ pub enum Kind {
     Zkr([u8; 32]),
 
     // param: batch id
-    Segment(u32),
+    Segment(u128),
 
     // param: batch id
-    Join(u32),
+    Join(u128),
 
     Groth16,
 }
@@ -52,7 +52,7 @@ pub struct Token {
 #[derive(Debug)]
 pub struct Job {
     // job id as specified by the client
-    pub base_id: String,
+    pub base_id: u128,
 
     // job_id as we know it: base_id+item_id
     pub id: String, 

--- a/src/job.rs
+++ b/src/job.rs
@@ -3,27 +3,15 @@ use std::collections::{
 };
 use libp2p::PeerId;
 
-#[derive(Debug, PartialEq, Eq)]
-pub enum Status {
-    WaitingForBlobs,
-
-    Running,
-    
-    ExecutionSucceded,
-    
-    // param: error message
-    ExecutionFailed(String),
-}
-
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Kind {
-    Assumption(u128),
-
     // param: batch id
+
     Segment(u128),
 
-    // param: batch id
     Join(u128),
+
+    Assumption(u128),
 
     Groth16(u128),
 }
@@ -36,7 +24,7 @@ pub struct Proof {
     pub blob: Vec<u8>
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Token {
     // xxh3_128
     pub hash: u128,
@@ -44,8 +32,7 @@ pub struct Token {
     pub owner: Vec<u8>
 }
 
-// maintain lifecycle of a job
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Job {
     // job id as specified by the client
     pub base_id: u128,
@@ -57,8 +44,6 @@ pub struct Job {
     
     // the client
     pub owner: PeerId,
-
-    pub status: Status,
 
     pub kind: Kind,
 
@@ -73,4 +58,3 @@ pub struct Job {
     // result of the job
     pub proof: Option<Proof>
 }
-

--- a/src/job.rs
+++ b/src/job.rs
@@ -41,7 +41,7 @@ pub struct Token {
     // xxh3_128
     pub hash: u128,
 
-    pub owners: Vec<Vec<u8>>
+    pub owner: Vec<u8>
 }
 
 // maintain lifecycle of a job

--- a/src/job.rs
+++ b/src/job.rs
@@ -16,14 +16,6 @@ pub enum Kind {
     Groth16(u128),
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct Proof {
-    // xxh3_128
-    pub hash: u128,
-
-    pub blob: Vec<u8>
-}
-
 #[derive(Debug, Clone)]
 pub struct Token {
     // xxh3_128
@@ -50,8 +42,6 @@ pub struct Job {
     // <index, token>
     pub prerequisites: BTreeMap<usize, Token>,
     // inverse helper map to put received blobs
-    pub pending_blobs: HashMap<u128, usize>,
+    pub pending_blobs: HashMap<u128, usize>
 
-    // result of the job
-    pub proof: Option<Proof>
 }

--- a/src/job.rs
+++ b/src/job.rs
@@ -35,10 +35,7 @@ pub struct Token {
 #[derive(Debug, Clone)]
 pub struct Job {
     // job id as specified by the client
-    pub base_id: u128,
-
-    // job_id as we know it: base_id+item_id
-    pub id: String, 
+    pub id: u128,
 
     // pub working_dir: String,
     

--- a/src/main.rs
+++ b/src/main.rs
@@ -306,6 +306,9 @@ async fn main() -> Result<(), Box<dyn Error + 'static>> {
                         },
 
                     };
+                    if !ready_jobs.is_empty() {
+                        continue;
+                    }
                     info!("Gossip: need `{need:?}`");
                     match need {
                         NeedKind::Prove(_num_jobs) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -693,15 +693,17 @@ async fn lookup_proof(
     col_proofs: &mongodb::Collection<db::Proof>,
     hash: u128
 ) -> anyhow::Result<Vec<u8>> {
-    let blob = col_proofs.find(
+    if let Some(proof) = col_proofs.find(
         doc! {
             "hash": hash.to_string()
         }
     )
     .await?
-    .try_next().await?
-    .unwrap()
-    .blob;
-
-    Ok(blob)
+    .try_next()
+    .await?
+    {
+        Ok(proof.blob)
+    } else {
+        Err(anyhow::Error::msg("Blob not found."))
+    }    
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,7 +122,7 @@ async fn main() -> Result<(), Box<dyn Error + 'static>> {
             let new_key = identity::Keypair::generate_ed25519();
             let bytes = new_key.to_protobuf_encoding().unwrap();
             let _bw = std::fs::write("./key.secret", bytes);
-            warn!("No keys were supplied, so one has been generated for you and saved to `{}` file.", "./key.secret");
+            warn!("No keys were supplied, so one is generated for you and saved to `./key.secret` file.");
             new_key
         }
     };    
@@ -304,7 +304,7 @@ async fn main() -> Result<(), Box<dyn Error + 'static>> {
                         },
 
                     };
-                    info!("Received `{need:#?}` need...");
+                    info!("Received `{need:?}` need...");
                     match need {
                         NeedKind::Prove(_num_jobs) => {
                             let _req_id = swarm
@@ -658,7 +658,7 @@ async fn main() -> Result<(), Box<dyn Error + 'static>> {
                 db_insert_futures.push(
                     col_proofs.insert_one(
                         db::Proof {
-                            client_job_id: job.base_id.clone(),
+                            client_job_id: job.base_id,
                             job_id: job.id.clone(),
                             kind: db::JobKind::Zkr(claim_digest),
                             owner: job.owner.to_string(),
@@ -713,7 +713,7 @@ async fn main() -> Result<(), Box<dyn Error + 'static>> {
                     
                     _ => {
                         warn!("No batch id is available for `{:?}`.", job.kind);
-                        u32::MAX
+                        u128::MAX
                     }
                 };
                 let blob_hash = xxh3_128(&res.blob);
@@ -721,7 +721,7 @@ async fn main() -> Result<(), Box<dyn Error + 'static>> {
                 db_insert_futures.push(
                     col_proofs.insert_one(
                         db::Proof {
-                            client_job_id: job.base_id.clone(),
+                            client_job_id: job.base_id,
                             job_id: job.id.clone(),
                             kind: db::JobKind::Segment(batch_id),
                             owner: job.owner.to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -352,7 +352,9 @@ async fn main() -> Result<(), Box<dyn Error + 'static>> {
                                             blob.clone()
                                         )
                                     );
-                                info!("Requested proof `{hash}` is found and sent back.");
+                                info!("Requested blob `{hash}` is found and sent back.");
+                            } else {
+                                warn!("Requested blob `{hash}` is not found.");
                             }
                         },
 
@@ -418,6 +420,10 @@ async fn main() -> Result<(), Box<dyn Error + 'static>> {
                                         compute_job.id,
                                         keccak_details.claim_digest
                                     );
+                                    if jobs.contains_key(&prove_id) {
+                                        warn!("Ignored duplicate job: `{prove_id}`");
+                                        continue
+                                    }
                                     // keep track of running jobs                
                                     jobs.insert(                    
                                         prove_id.clone(),

--- a/src/r0.rs
+++ b/src/r0.rs
@@ -79,7 +79,6 @@ async fn aggregate_proofs(
     job_id: String,
     blobs: Vec<Vec<u8>>
 ) -> Result<ExecutionResult, ExecutionError> {
-    info!("Aggregating proofs for `{job_id}`");
     let first = match 
         bincode::deserialize::<SuccinctReceipt<ReceiptClaim>>(
             &blobs[0]
@@ -121,11 +120,6 @@ async fn aggregate_segments(
     job_id: String,
     blobs: Vec<Vec<u8>>
 ) -> Result<ExecutionResult, ExecutionError> {
-    info!(
-        "Aggregating segments for `{}`, `{}` in total.",
-        job_id,
-        blobs.len(),
-    );
     let mut receipts = Vec::new();
     for (i, blob) in blobs.into_iter().enumerate() {
         match prove_and_lift_segment(blob) {
@@ -145,7 +139,7 @@ async fn aggregate_segments(
         };        
     }
     info!(
-        "Joining receipts, {} in total.",
+        "Joining receipts, `{}` operations in total.",
         receipts.len() - 1
     );
     let first = receipts.remove(0);
@@ -169,9 +163,17 @@ async fn aggregate_segments(
 pub async fn aggregate(
     job_id: String,
     blobs: Vec<Vec<u8>>,
-    are_blobs_segment: bool
+    blobs_are_segment: bool
 ) -> Result<ExecutionResult, ExecutionError> {
-    if are_blobs_segment {
+    info!(
+        "Aggregating: {}",
+        if blobs_are_segment {
+            format!("`{}` segment(s) to prove.", blobs.len())
+        } else {
+            format!("`{}` receipt(s) to join.", blobs.len())
+        }
+    );
+    if blobs_are_segment {
         aggregate_segments(job_id, blobs).await
     } else {
         aggregate_proofs(job_id, blobs).await

--- a/src/r0.rs
+++ b/src/r0.rs
@@ -95,12 +95,11 @@ async fn aggregate_proofs(
                 }
             )
         }
-
-    };
+    };    
     blobs
         .into_iter()
         .skip(1)
-        .try_fold(first, |agg, r| join_proofs(agg, r))
+        .try_fold(first, |agg, r| join_proofs(agg, r))            
         .and_then(|proof|
             Ok(
                 ExecutionResult {
@@ -122,11 +121,16 @@ async fn aggregate_segments(
     job_id: String,
     blobs: Vec<Vec<u8>>
 ) -> Result<ExecutionResult, ExecutionError> {
-    info!("Aggregating segments for `{job_id}`");
+    info!(
+        "Aggregating segments for `{}`, `{}` in total.",
+        job_id,
+        blobs.len(),
+    );
     let mut receipts = Vec::new();
-    for blob in blobs.into_iter() {
+    for (i, blob) in blobs.into_iter().enumerate() {
         match prove_and_lift_segment(blob) {
             Ok(sr) => {
+                info!("`{i}th` segment was proved with success.");
                 receipts.push(sr)
             },
 
@@ -140,7 +144,11 @@ async fn aggregate_segments(
             }
         };        
     }
-    let first = receipts.remove(0);    
+    info!(
+        "Joining receipts, {} in total.",
+        receipts.len() - 1
+    );
+    let first = receipts.remove(0);
     receipts
         .into_iter()
         .try_fold(first, |agg, r| join_receipts(agg, r))

--- a/src/r0.rs
+++ b/src/r0.rs
@@ -139,7 +139,7 @@ async fn aggregate_segments(
         };        
     }
     info!(
-        "Joining receipts, `{}` operations in total.",
+        "Joining receipts, `{}` operation(s) in total.",
         receipts.len() - 1
     );
     let first = receipts.remove(0);

--- a/src/r0.rs
+++ b/src/r0.rs
@@ -65,7 +65,7 @@ fn join_proofs(
 // given a list of segment blobs, aggregate them into a final proof
 // input: n segments
 // output: 1 proof
-async fn aggregate_proofs(blobs: Vec<Vec<u8>>) -> anyhow::Result<Vec<u8>> {
+fn aggregate_proofs(blobs: Vec<Vec<u8>>) -> anyhow::Result<Vec<u8>> {
     info!(
         "Aggregating proofs, `{}` operations in total.",
         blobs.len() - 1
@@ -81,7 +81,7 @@ async fn aggregate_proofs(blobs: Vec<Vec<u8>>) -> anyhow::Result<Vec<u8>> {
 // given a list of segment blobs, aggregate them into a final proof
 // input: n segments
 // output: 1 proof
-async fn aggregate_segments(
+fn aggregate_segments(
     blobs: Vec<Vec<u8>>
 ) -> anyhow::Result<Vec<u8>> {
     info!(
@@ -118,7 +118,7 @@ fn prove_zkr(
         .prove_zkr(zkr_req, AssetRequest::Inline)
 }
 
-async fn prove_assumption(
+fn prove_assumption(
     blob: Vec<u8>,
 ) -> anyhow::Result<Vec<u8>> {
     if let Ok(k) = bincode::deserialize::<KeccakRequestObject>(&blob) {
@@ -152,7 +152,7 @@ async fn prove_assumption(
     }
 }
 
-async fn to_groth16(
+fn to_groth16(
     blob: Vec<u8>
 ) -> anyhow::Result<Vec<u8>> {
     info!("Extracting Groth16 proof...");
@@ -174,27 +174,27 @@ async fn to_groth16(
     Ok(bincode::serialize(&groth16_proof)?)
 }
 
-pub async fn prove(
+pub fn prove(
     blobs: Vec<Vec<u8>>,
     kind: Kind
 ) -> anyhow::Result<Vec<u8>> {    
     match kind {
         Kind::Segment(_) => {
-            aggregate_segments(blobs).await
+            aggregate_segments(blobs)
         },
 
         Kind::Join(_) => {
-            aggregate_proofs(blobs).await
+            aggregate_proofs(blobs)
         },        
 
         Kind::Assumption(_) => {            
             let first = blobs.into_iter().next().unwrap();
-            prove_assumption(first).await
+            prove_assumption(first)
         },
 
         Kind::Groth16(_) => {
             let first = blobs.into_iter().next().unwrap();
-            to_groth16(first).await
+            to_groth16(first)
         }
     }
 }


### PR DESCRIPTION
This PR pushes for a lean prover code base. There are notable changes:
- proving only one job at a time.
- proving is pushed to worker threads with the main thread engaging with network-wide requests.

the Keccak test was successful and it is time to prove ETH blocks.